### PR TITLE
Improvements to Servo functionality

### DIFF
--- a/examples/servo.js
+++ b/examples/servo.js
@@ -8,6 +8,4 @@ var servo = new arduino.Servo({
   board: board
 });
 
-board.on('ready', function(){
-  servo.sweep();
-});
+servo.sweep();

--- a/examples/servo.js
+++ b/examples/servo.js
@@ -1,22 +1,50 @@
-var arduino = require('../');
+var arduino = require('../'),
+    board, led, servo;
 
-var board = new arduino.Board({
+// Construct instances
+board = new arduino.Board({
   debug: true
 });
 
-var servo = new arduino.Servo({
+led = new arduino.Led({
   board: board,
-  pin: "A0"
+  pin: 13
 });
 
+servo = new arduino.Servo({
+  board: board,
+  pin: 9
+});
 
+// Once servo is attached:
+//  - "read"
+//      - log position
+//  - "aftersweep"
+//      - blink the led
+//      - read the position
+//      - detach the servo
+//  - "detached"
+//      - log detach message
+//
+//  - execute full sweep
 
-servo.on("attached", function() {
+servo.on('attached', function() {
+  console.log('attached');
 
-  this.read(function(current) {
-    this.write(180);
+  this.on('read', function(pos) {
+    console.log(pos);
   });
 
+  this.on('detached', function() {
+    console.log('detached');
+  });
 
+  this.on('aftersweep', function() {
+    led.blink();
 
+    this.read();
+    this.detach();
+  });
+
+  this.sweep();
 });

--- a/examples/servo.js
+++ b/examples/servo.js
@@ -5,7 +5,18 @@ var board = new arduino.Board({
 });
 
 var servo = new arduino.Servo({
-  board: board
+  board: board,
+  pin: "A0"
 });
 
-servo.sweep();
+
+
+servo.on("attached", function() {
+
+  this.read(function(current) {
+    this.write(180);
+  });
+
+
+
+});

--- a/lib/board.js
+++ b/lib/board.js
@@ -125,19 +125,17 @@ Board.prototype.write = function (m) {
  * Add a 0 to the front of a single-digit pin number
  */
 Board.prototype.normalizePin = function (pin) {
-  return ("00" + pin).substr(-2);
-	/*pin = String(pin).split('');
-  if (pin.length > 1) {
-    return pin.join('');
-  } else {
-    pin.unshift('0');
-    return pin.join('');
-  }*/
+  return this.lpad( 2, "0", pin );
 }
 
 Board.prototype.normalizeVal = function(val) {
-	return ("000" + val).substr(-3);
+	return this.lpad( 3, "0", val );
 }
+
+//
+Board.prototype.lpad = function(len, chr, str) {
+  return (Array(len + 1).join(chr || ' ') + str).substr(-len);
+};
 
 /*
  * Define constants
@@ -204,8 +202,9 @@ Board.prototype.delay = function (ms) {
  * Logger utility function
  */
 Board.prototype.log = function (level, message) {
+  var args = [].slice.call(arguments);
   if (this.debug) {
-    console.log(String(+new Date()).grey + ' duino '.blue + level.magenta + ' ' + message);
+    console.log(String(+new Date()).grey + ' duino '.blue + args.shift().magenta + ' ' + args.join(", "));
   }
 }
 

--- a/lib/board.js
+++ b/lib/board.js
@@ -73,7 +73,7 @@ Board.prototype.detect = function (cb) {
       try {
         tempSerial = new serial.SerialPort('/dev/' + possible[i], {
           baudrate: 115200,
-          parser: serial.parsers.readline("\n")
+          parser: serial.parsers.readline('\n')
         });
       } catch (e) {
         err = e;
@@ -125,11 +125,11 @@ Board.prototype.write = function (m) {
  * Add a 0 to the front of a single-digit pin number
  */
 Board.prototype.normalizePin = function (pin) {
-  return this.lpad( 2, "0", pin );
+  return this.lpad( 2, '0', pin );
 }
 
 Board.prototype.normalizeVal = function(val) {
-	return this.lpad( 3, "0", val );
+	return this.lpad( 3, '0', val );
 }
 
 //
@@ -204,7 +204,7 @@ Board.prototype.delay = function (ms) {
 Board.prototype.log = function (level, message) {
   var args = [].slice.call(arguments);
   if (this.debug) {
-    console.log(String(+new Date()).grey + ' duino '.blue + args.shift().magenta + ' ' + args.join(", "));
+    console.log(String(+new Date()).grey + ' duino '.blue + args.shift().magenta + ' ' + args.join(', '));
   }
 }
 

--- a/lib/board.js
+++ b/lib/board.js
@@ -201,7 +201,7 @@ Board.prototype.delay = function (ms) {
 /*
  * Logger utility function
  */
-Board.prototype.log = function (level, message) {
+Board.prototype.log = function (/*level, message*/) {
   var args = [].slice.call(arguments);
   if (this.debug) {
     console.log(String(+new Date()).grey + ' duino '.blue + args.shift().magenta + ' ' + args.join(', '));

--- a/lib/servo.js
+++ b/lib/servo.js
@@ -1,3 +1,6 @@
+var events = require('events'),
+    util = require('util');
+
 /*
  * Main Servo constructor
  * Process options
@@ -7,32 +10,139 @@ var Servo = function (options) {
   if (!options || !options.board) throw new Error('Must supply required options to Sutton');
   this.board = options.board;
   this.pin = this.board.normalizePin(options.pin || 9);
-  var self = this;
-  this.board.on('ready', function () {
-    self.attach();
-  });
-}
 
-Servo.prototype.write = function (pos) {
-  this.board.write('98' + this.pin + '02' + pos);
-}
+  var types = {
+    attached: true,
+    detached: true,
+    read: true,
+    moved: true
+  };
+
+  this.board.on('ready', function () {
+    this.attach();
+  }.bind(this));
+
+  this.board.on('data', function (message) {
+    var m = message.slice(0, -1).split('::'),
+        pin, type, data;
+
+    if (!m.length) {
+      return;
+    }
+
+    pin = m[0]
+    type = m[1];
+    data = m.length === 3 ? m[2] : null;
+
+    if (pin === this.pin && types[type]) {
+      this.emit(type, data);
+    }
+  }.bind(this));
+};
+
+util.inherits(Servo, events.EventEmitter);
+
+Servo.prototype.command = function () {
+  var msg = '98' + this.pin + ([].slice.call(arguments).join(''));
+
+  // this.board.log( 'info', 'command', msg );
+  this.board.write(msg);
+};
+
+Servo.prototype.detach = function () {
+  this.command('00');
+};
 
 Servo.prototype.attach = function () {
-  this.board.write('98' + this.pin + '01');
-}
+  this.command('01');
+};
 
-Servo.prototype.read = function () {}
-Servo.prototype.detach = function () {}
-Servo.prototype.writeMilliseconds = function () {}
-Servo.prototype.attached = function () {}
+Servo.prototype.write = function (pos) {
+  pos = this.board.lpad(3, '0', pos);
+  this.board.log('info', 'moving to: ' + pos);
+  this.command('02' + pos);
+};
 
-Servo.prototype.sweep = function () {
-  var self = this;
-  var pos = 0;
-  setInterval(function() {
-    self.write(pos++);
-    if (pos == 180) clearInterval(this);
-  }, 25);
-}
+Servo.prototype.read = function (callback) {
+  this.command('03');
+};
+
+// Servo.prototype.writeMilliseconds = function () {};
+// Servo.prototype.attached = function (callback) {
+//   this.callbacks.attached.push(callback);
+// };
+
+Servo.prototype.sweep = function (options) {
+  // Ensure no missing options object
+  options = options || {};
+
+  var timeout = {
+        inner: null,
+        outer: null
+      },
+      moves = 0,
+      // sweep settings
+      lapse = options.lapse || 500,
+      to = options.to || 180,
+      from = options.from || 1;
+      // sweep handlers
+      doSweep = function doSweep(pos) {
+        // this.board.log('info', 'current position: ', pos);
+        var moveTo,
+            posint = +pos;
+
+        // this.board.log('info', 'current pos int: ', posint);
+
+        if (posint === 93) {
+          moveTo = 1;
+        } else {
+
+          // this.board.log('info', 'posint not 93.....');
+
+          if (posint < to) {
+            moveTo = to;
+          } else if (posint == to) {
+            moveTo = 90;
+          } else {
+            moveTo = from;
+          }
+        }
+
+        this.write(moveTo);
+
+        moves++;
+
+        // this.board.log( 'info', 'moves: ', moves );
+      };
+
+  this.on('read', doSweep);
+
+  // this.write(1);
+
+  // Initialize sweep; wait for for stack unwind.
+  timeout.outer = setTimeout(function loop() {
+    // Read the current position, will trigger
+    // 'read' event with position data;
+
+
+    if (moves < 2) {
+      this.read();
+
+      timeout.inner = setTimeout(loop.bind(this), lapse);
+    } else {
+      // this.board.log('info', 'info', 'clearing');
+
+      clearTimeout(timeout.inner);
+      clearTimeout(timeout.outer);
+
+      loop = null;
+
+      this.removeListener('read', doSweep);
+      this.emit.call(this, 'aftersweep');
+
+      // this.board.log('info', this);
+    }
+  }.bind(this), 0);
+};
 
 module.exports = Servo;

--- a/lib/servo.js
+++ b/lib/servo.js
@@ -63,7 +63,7 @@ Servo.prototype.write = function (pos) {
   this.command('02' + pos);
 };
 
-Servo.prototype.read = function (callback) {
+Servo.prototype.read = function () {
   this.command('03');
 };
 

--- a/src/du.ino
+++ b/src/du.ino
@@ -1,5 +1,6 @@
 #include <Servo.h>
 
+
 char messageBuffer[12];
 int index = 0;
 char cmd[3];
@@ -7,6 +8,7 @@ char pin[3];
 char val[4];
 char aux[4];
 bool debug = false;
+int pos = 0;
 Servo servo;
 
 void setup() {
@@ -166,14 +168,54 @@ void handleServo(char *pin, char *val, char *aux) {
   int p = getPin(pin);
   if(p == -1) { if(debug) Serial.println("badpin"); return; }
   Serial.println("got signal");
+
   if (atoi(val) == 0) {
     servo.detach();
+    Serial.println("detached");
   } else if (atoi(val) == 1) {
     servo.attach(p);
     Serial.println("attached");
   } else if (atoi(val) == 2) {
     Serial.println("writing to servo");
     Serial.println(atoi(aux));
-    servo.write(atoi(aux));
+
+    // servo.write(atoi(aux));
+    moveTo( atoi(aux) );
+
+  } else if (atoi(val) == 3) {
+    Serial.println("reading servo");
+    int sval = servo.read();
+    char m[8];
+    sprintf(m, "%s::%03d::read", pin, sval);
+    Serial.println(m);
+  }
+  //delay(15);
+}
+
+// move to the given position
+void moveTo(int pos) {
+  int step = 4;  // decrease this to slow movement
+  int current = servo.read();
+  int movement = pos - current; // the  number of degrees to move
+
+  Serial.println(movement);
+  if (movement < 0) {
+    while (current > pos) {
+      current = current - step;
+      if (current < pos)
+        current = pos;
+
+      servo.write( current);
+      delay(15);
+    }
+  } else {
+    while (current < pos) {
+      current = current + step;
+      if (current > pos)
+        current = pos;
+
+      servo.write( current);
+      delay(15);
+    }
   }
 }

--- a/src/du.ino
+++ b/src/du.ino
@@ -27,21 +27,21 @@ void loop() {
  */
 void process() {
   index = 0;
-  
+
   strncpy(cmd, messageBuffer, 2);
   cmd[2] = '\0';
   strncpy(pin, messageBuffer + 2, 2);
   pin[2] = '\0';
-  strncpy(val, messageBuffer + 4, 3);
+  strncpy(val, messageBuffer + 4, 2);
   val[3] = '\0';
-  strncpy(aux, messageBuffer + 7, 3);
+  strncpy(aux, messageBuffer + 6, 3);
   aux[3] = '\0';
-  
+
   if (debug) {
     Serial.println(messageBuffer);
   }
   int cmdid = atoi(cmd);
-  
+
   switch(cmdid) {
     case 0:  sm(pin,val);              break;
     case 1:  dw(pin,val);              break;
@@ -122,7 +122,7 @@ void ar(char *pin, char *val) {
   char m[8];
   sprintf(m, "%s::%03d", pin, rval);
   Serial.println(m);
-}  
+}
 
 void aw(char *pin, char *val) {
   if(debug) Serial.println("aw");
@@ -155,7 +155,7 @@ int getPin(char *pin) { //Converts to A0-A5, and returns -1 on error
   }
   return ret;
 }
-  
+
 
 /*
  * Handle Servo commands

--- a/src/du.ino
+++ b/src/du.ino
@@ -1,14 +1,18 @@
 #include <Servo.h>
 
 
-char messageBuffer[12];
+bool debug = false;
+
 int index = 0;
+
+char messageBuffer[12];
 char cmd[3];
 char pin[3];
 char val[4];
 char aux[4];
-bool debug = false;
-int pos = 0;
+
+
+
 Servo servo;
 
 void setup() {
@@ -171,50 +175,29 @@ void handleServo(char *pin, char *val, char *aux) {
 
   if (atoi(val) == 0) {
     servo.detach();
-    Serial.println("detached");
+    char m[12];
+    sprintf(m, "%s::detached", pin);
+    Serial.println(m);
   } else if (atoi(val) == 1) {
-    servo.attach(p);
-    Serial.println("attached");
+    servo.attach(p, 600, 2200);
+    char m[12];
+    sprintf(m, "%s::attached", pin);
+    Serial.println(m);
   } else if (atoi(val) == 2) {
     Serial.println("writing to servo");
     Serial.println(atoi(aux));
-
+    // Write to servo
     servo.write(atoi(aux));
-    // moveTo( atoi(aux) );
 
+    // TODO: Experiment with microsecond pulses
+    // digitalWrite(pin, HIGH);   // start the pulse
+    // delayMicroseconds(pulseWidth);  // pulse width
+    // digitalWrite(pin, LOW);    // stop the pulse
   } else if (atoi(val) == 3) {
     Serial.println("reading servo");
     int sval = servo.read();
     char m[8];
-    sprintf(m, "%s::%03d::read", pin, sval);
+    sprintf(m, "%s::read::%03d", pin, sval);
     Serial.println(m);
   }
 }
-
-// // move to the given position
-// void moveTo(int pos) {
-//   int step = 4;  // decrease this to slow movement
-//   int current = servo.read();
-//   int movement = pos - current; // the  number of degrees to move
-
-//   Serial.println(movement);
-//   if (movement < 0) {
-//     while (current > pos) {
-//       current = current - step;
-//       if (current < pos)
-//         current = pos;
-
-//       servo.write( current);
-//       delay(15);
-//     }
-//   } else {
-//     while (current < pos) {
-//       current = current + step;
-//       if (current > pos)
-//         current = pos;
-
-//       servo.write( current);
-//       delay(15);
-//     }
-//   }
-// }

--- a/src/du.ino
+++ b/src/du.ino
@@ -179,8 +179,8 @@ void handleServo(char *pin, char *val, char *aux) {
     Serial.println("writing to servo");
     Serial.println(atoi(aux));
 
-    // servo.write(atoi(aux));
-    moveTo( atoi(aux) );
+    servo.write(atoi(aux));
+    // moveTo( atoi(aux) );
 
   } else if (atoi(val) == 3) {
     Serial.println("reading servo");
@@ -189,33 +189,32 @@ void handleServo(char *pin, char *val, char *aux) {
     sprintf(m, "%s::%03d::read", pin, sval);
     Serial.println(m);
   }
-  //delay(15);
 }
 
-// move to the given position
-void moveTo(int pos) {
-  int step = 4;  // decrease this to slow movement
-  int current = servo.read();
-  int movement = pos - current; // the  number of degrees to move
+// // move to the given position
+// void moveTo(int pos) {
+//   int step = 4;  // decrease this to slow movement
+//   int current = servo.read();
+//   int movement = pos - current; // the  number of degrees to move
 
-  Serial.println(movement);
-  if (movement < 0) {
-    while (current > pos) {
-      current = current - step;
-      if (current < pos)
-        current = pos;
+//   Serial.println(movement);
+//   if (movement < 0) {
+//     while (current > pos) {
+//       current = current - step;
+//       if (current < pos)
+//         current = pos;
 
-      servo.write( current);
-      delay(15);
-    }
-  } else {
-    while (current < pos) {
-      current = current + step;
-      if (current > pos)
-        current = pos;
+//       servo.write( current);
+//       delay(15);
+//     }
+//   } else {
+//     while (current < pos) {
+//       current = current + step;
+//       if (current > pos)
+//         current = pos;
 
-      servo.write( current);
-      delay(15);
-    }
-  }
-}
+//       servo.write( current);
+//       delay(15);
+//     }
+//   }
+// }

--- a/src/du.ino
+++ b/src/du.ino
@@ -179,7 +179,7 @@ void handleServo(char *pin, char *val, char *aux) {
     sprintf(m, "%s::detached", pin);
     Serial.println(m);
   } else if (atoi(val) == 1) {
-    servo.attach(p, 600, 2200);
+    servo.attach(p, 100, 2200);
     char m[12];
     sprintf(m, "%s::attached", pin);
     Serial.println(m);


### PR DESCRIPTION
To be honest, I'm hesitant to submit this pull request. I understand it's a lot of code, none of which was discussed in a ticket/issue. This patch set is the result of my actual use case needs for controlling a servo, which resulted in adopting a Event Emitter base prototype that:
- supports reading a servo (which actually requires writing to the arduino via the serialport to request a `servo.read()`)
- supports detaching a servo
- emits an event to indicate a servo has been:
  - attached
  - detached
  - read
- supports a flexible `sweep` that allows setting **to** and **from** degree and time **lapse**
- emits an event to indicate a sweep is complete

I wish I could provide unit tests for all of these features, but as no testing suite exists and I already feel as though I my have overstepped, I chose to just create example files that illustrate the use cases.

All of these changes were developed on an Arduino UNO with protoshield and stock servo.
