### PR TITLE
Make the baud rate configurable

### DIFF
--- a/examples/adjustable-baud.js
+++ b/examples/adjustable-baud.js
@@ -1,0 +1,15 @@
+var arduino = require('../');
+
+var board = new arduino.Board({
+  debug: true,
+  baudrate: 9600
+});
+
+var led = new arduino.Led({
+  board: board,
+  pin: 9
+});
+
+board.on('ready', function(){
+  led.blink();
+});

--- a/lib/board.js
+++ b/lib/board.js
@@ -12,6 +12,7 @@ var events = require('events'),
 var Board = function (options) {
   this.log('info', 'initializing');
   this.debug = options && options.debug || false;
+  this.baudrate = options && options.baudrate || 115200;
   this.writeBuffer = [];
 
   var self = this;
@@ -83,7 +84,7 @@ Board.prototype.detect = function (callback) {
       if (possible.slice(0, 2) !== 'cu') {
         try {
           temp = new serial.SerialPort('/dev/' + possible, {
-            baudrate: 115200,
+            baudrate: self.baudrate,
             parser: serial.parsers.readline('\n')
           });
         } catch (e) {


### PR DESCRIPTION
On my Arduino Pro Mini 3.3v the 115200 baud rate is too high for the
signals to get processed properly.
