### PR TITLE
Fix hang after SIGINT in debug mode

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -42,10 +42,10 @@ var Board = function (options) {
           process.on('SIGINT', function(){
             self.log('info', 'sending debug mode toggle off to board');
             self.write('99' + self.normalizePin(0) + self.normalizeVal(0));
-            delete self.serial;
-            setTimeout(function(){
-              process.exit();
-            }, 100);
+            self.serial.once('close', function() {
+              setTimeout(process.exit, 100);
+            });
+            self.serial.close();
           });
         }
 


### PR DESCRIPTION
Sending SIGINT (^c) to the process when in debug mode causes the
process to (at least appear to) hang, because the serial port is still
open.  Instead of deleting our reference to the serialport, call its
close method, and then call process.exit in the handler for the close
event.
