### PR TITLE
Change board's ready trigger / Ensure attachment of servos

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -94,7 +94,7 @@ Board.prototype.detect = function (callback) {
         }
         if (!err) {
           found = temp;
-          self.log('info', 'found board at ' + temp.port);
+          self.log('info', 'found board at ' + temp.path);
           break;
         } else {
           err = new Error('Could not find Arduino');

--- a/lib/board.js
+++ b/lib/board.js
@@ -32,7 +32,7 @@ var Board = function (options) {
         self.emit('data', data);
       });
 
-      setTimeout(function(){
+      self.serial.on('open', function() {
         self.log('info', 'board ready');
         self.sendClearingBytes();
 
@@ -53,8 +53,10 @@ var Board = function (options) {
           self.processWriteBuffer();
         }
 
-        self.emit('ready');      
-      }, 500);
+        setTimeout(function() {
+          self.emit('ready');
+        }, 500);
+      });
     }
   });
 }

--- a/lib/servo.js
+++ b/lib/servo.js
@@ -18,10 +18,15 @@ var Servo = function (options) {
     moved: true
   };
 
-  this.board.on('ready', function () {
-    console.log('board ready, attaching servo', this);
+  if (this.board.serial && this.board.serial.readStream) {
+    console.log('board already ready, attaching servo', this);
     this.attach();
-  }.bind(this));
+  } else {
+    this.board.on('ready', function () {
+      console.log('board ready, attaching servo', this);
+      this.attach();
+    }.bind(this));
+  }
 
   this.board.on('data', function (message) {
     var m = message.slice(0, -1).split('::'),


### PR DESCRIPTION
Thanks for your work ecto, duino is really cool and easy to get into, good job!

Anyway, this PR fixes #21.

It was a sort of racing condition where the board would sometimes trigger the `ready` event earlier and it should, now it listens for serialport's `open` event.
Also I made it so that you can use servos inside the board's `ready` event callback.
Lastly updated the board's name property to `path` based on serialport's.

Cheers
