### PR TITLE
Use `chalk` for color log instead of `colors`

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -2,7 +2,7 @@
 var events = require('events'),
     child  = require('child_process'),
     util   = require('util'),
-    colors = require('colors'),
+    chalk  = require('chalk'),
     serial = require('serialport');
 
 /*
@@ -29,7 +29,7 @@ var Board = function (options) {
 
       self.log('info', 'binding serial events');
       self.serial.on('data', function(data){
-        self.log('receive', data.toString().red);
+        self.log('receive', chalk.red(data.toString()));
         self.emit('data', data);
       });
 
@@ -132,7 +132,7 @@ Board.prototype.write = function (m) {
     this.log('write', m);
     this.serial.write('!' + m + '.');
   } else {
-    this.log('info', 'serial not ready, buffering message: ' + m.red);
+    this.log('info', 'serial not ready, buffering message: ' + chalk.red(m));
     this.writeBuffer.push(m);
   }
 }
@@ -181,7 +181,7 @@ Board.prototype.pinMode = function (pin, val) {
 Board.prototype.digitalWrite = function (pin, val) {
   pin = this.normalizePin(pin);
   val = this.normalizeVal(val);
-  this.log('info', 'digitalWrite to pin ' + pin + ': ' + val.green);
+  this.log('info', 'digitalWrite to pin ' + pin + ': ' + chalk.green(val));
   this.write('01' + pin + val);
 }
 
@@ -197,7 +197,7 @@ Board.prototype.digitalRead = function (pin) {
 Board.prototype.analogWrite = function (pin, val) {
 	pin = this.normalizePin(pin);
 	val = this.normalizeVal(val);
-	this.log('info', 'analogWrite to pin ' + pin + ': ' + val.green);
+	this.log('info', 'analogWrite to pin ' + pin + ': ' + chalk.green(val));
 	this.write('03' + pin + val);
 }
 Board.prototype.analogRead = function (pin) {
@@ -220,7 +220,7 @@ Board.prototype.delay = function (ms) {
 Board.prototype.log = function (/*level, message*/) {
   var args = [].slice.call(arguments);
   if (this.debug) {
-    console.log(String(+new Date()).grey + ' duino '.blue + args.shift().magenta + ' ' + args.join(', '));
+    console.log(chalk.gray(Date.now()) + chalk.blue(' duino ') + chalk.magenta(args.shift()) + ' ' + args.join(', '));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "serialport": "*",
-    "colors": "*"
+    "chalk": "*"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Not critical by any means, but why not ditch `colors`. Fixes #49
