### PR TITLE
More robust serial connection establishment & error handling

### DIFF
--- a/examples/adjustable-baud.js
+++ b/examples/adjustable-baud.js
@@ -3,7 +3,7 @@ var arduino = require('../');
 var board = new arduino.Board({
   debug: true,
   baudrate: 9600
-});
+}).setup();
 
 var led = new arduino.Led({
   board: board,

--- a/examples/adjustable-port.js
+++ b/examples/adjustable-port.js
@@ -3,7 +3,7 @@ var arduino = require('../');
 var board = new arduino.Board({
   debug: true,
   device: "ACM"
-});
+}).setup();
 
 var led = new arduino.Led({
   board: board,

--- a/examples/analogled.js
+++ b/examples/analogled.js
@@ -2,7 +2,7 @@ var arduino = require('../');
 
 var board = new arduino.Board({
   debug: true
-});
+}).setup();
 
 var aled = new arduino.Led({
 	board: board,

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,7 +1,7 @@
 
 var arduino = require('../');
 
-var board = new arduino.Board();
+var board = new arduino.Board().setup();
 
 board.on('connected', function(){
   board.write('HELLO WORLD');

--- a/examples/button.js
+++ b/examples/button.js
@@ -1,6 +1,6 @@
 var arduino = require('../');
 
-var board = new arduino.Board();
+var board = new arduino.Board().setup();
 
 var button = new arduino.Button({
   board: board,

--- a/examples/combination.js
+++ b/examples/combination.js
@@ -1,6 +1,6 @@
 var arduino = require('../');
 
-var board = new arduino.Board();
+var board = new arduino.Board().setup();
 
 var button = new arduino.Button({
   board: board,

--- a/examples/led.js
+++ b/examples/led.js
@@ -2,11 +2,11 @@ var arduino = require('../');
 
 var board = new arduino.Board({
   debug: true
-});
+}).setup();
 
 var led = new arduino.Led({
   board: board,
-  pin: "A0"
+  pin: "13"
 });
 
 board.on('ready', function(){

--- a/examples/piezo.js
+++ b/examples/piezo.js
@@ -2,7 +2,7 @@ var arduino = require('../');
 
 var board = new arduino.Board({
   debug: true
-});
+}).setup();
 
 var piezo = new arduino.Piezo({
   board: board

--- a/examples/ping.js
+++ b/examples/ping.js
@@ -3,7 +3,7 @@ var arduino = require('../'),
 
 board = new arduino.Board({
   debug: false
-});
+}).setup();
 
 ping = new arduino.Ping({
   board: board,

--- a/examples/pir.js
+++ b/examples/pir.js
@@ -3,7 +3,7 @@ var arduino = require('../'),
 
 board = new arduino.Board({
   debug: false
-});
+}).setup();
 
 pir = new arduino.PIR({
   board: board,

--- a/examples/sensor-throttled.js
+++ b/examples/sensor-throttled.js
@@ -3,7 +3,7 @@ var arduino = require('../'),
 
 board = new arduino.Board({
   debug: false
-});
+}).setup();
 
 sensor = new arduino.Sensor({
   board: board,

--- a/examples/sensor.js
+++ b/examples/sensor.js
@@ -3,7 +3,7 @@ var arduino = require('../'),
 
 board = new arduino.Board({
   debug: true
-});
+}).setup();
 
 sensor = new arduino.Sensor({
   board: board,

--- a/examples/servo.js
+++ b/examples/servo.js
@@ -4,7 +4,7 @@ var arduino = require('../'),
 // Construct instances
 board = new arduino.Board({
   debug: true
-});
+}).setup();
 
 led = new arduino.Led({
   board: board,

--- a/lib/board.js
+++ b/lib/board.js
@@ -77,6 +77,7 @@ Board.prototype.setup = function() {
       }
     }
   });
+  return this;
 }
 
 /*
@@ -238,8 +239,8 @@ Board.prototype.analogRead = function (pin) {
  * Utility function to pause for a given time
  */
 Board.prototype.delay = function (ms) {
-  ms += +new Date();
-  while (+new Date() < ms) { }
+  ms += Date.now();
+  while (Date.now() < ms) { }
 }
 
 /*

--- a/lib/board.js
+++ b/lib/board.js
@@ -1,4 +1,3 @@
-
 var events = require('events'),
     child  = require('child_process'),
     util   = require('util'),
@@ -7,24 +6,37 @@ var events = require('events'),
 
 /*
  * The main Arduino constructor
- * Connect to the serial port and bind
+ *
+ * [NEW] Does *not* open a serial connection. Add a `setup()` call to do so.
+ *
+ * This allows the user to add a listener for error events that occur
+ * during the serial connection attempts.
  */
 var Board = function (options) {
   this.log('info', 'initializing');
-  this.debug = options && options.debug || false;
-  this.device = options && options.device || 'usb|ttyACM*|ttyS0';
+  this.debug    = options && options.debug    || false;
+  this.devregex = options && options.devregex || 'usb|ttyACM*|ttyS0';
   this.baudrate = options && options.baudrate || 115200;
   this.writeBuffer = [];
+}
 
+/*
+ * EventEmitter, I choose you!
+ */
+util.inherits(Board, events.EventEmitter);
+
+/*
+ * Establish the serial connection
+ *
+ * Tries to open a serial connection with `connectSerial()`.
+ * If successful, the connection is initialized ("clearing bytes", debug mode).
+ * If unsuccessful, error event is emitted; if no listeners: error is thrown.
+ */
+Board.prototype.setup = function() {
   var self = this;
-  this.detect(function (err, serial) {
-    if (err) {
-      if(self.listeners('error').length)
-        self.emit('error', err);
-      else
-        throw new Error(err);
-    }else{
-      self.serial = serial;
+  this.connectSerial(function(found) {
+    if (found) {
+      self.serial = found;
       self.emit('connected');
 
       self.log('info', 'binding serial events');
@@ -56,52 +68,69 @@ var Board = function (options) {
 
         self.emit('ready');      
       }, 500);
+    } else {
+      msg = "Could not establish Serial connection to Arduino.";
+      if (self.listeners('error').length > 0) {
+        self.emit('error', msg);
+      } else {
+        throw new Error(msg);
+      }
     }
   });
 }
 
 /*
- * EventEmitter, I choose you!
+ * (Tries to) Open serial connection with Arduino (formerly named `detect()`)
+ *
+ * Loops through devices matching `devregex` and naively tries to open a serial
+ * connection with each until one succeeds.
+ * This should really message the device and wait for a correct response to
+ * ensure that we're actually connected to an Arduino running `duino`. FIXME
+ *
+ * Returns false if no serial connection could be established.
  */
-util.inherits(Board, events.EventEmitter);
-
-/*
- * Detect an Arduino board
- * Loop through all USB devices and try to connect
- * This should really message the device and wait for a correct response
- */
-Board.prototype.detect = function (callback) {
+Board.prototype.connectSerial = function (callback) {
   this.log('info', 'attempting to find Arduino board');
   var self = this;
-  child.exec('ls /dev | grep -E "'+ self.device +'"', function(err, stdout, stderr){
-    var usb = stdout.slice(0, -1).split('\n'),
-        found = false,
-        err = null,
-        possible, temp;
+  child.exec('ls /dev | grep -E "'+ self.devregex +'"', function(err, stdout, stderr){
 
-    while ( usb.length ) {
-      possible = usb.pop();
-
-      if (possible.slice(0, 2) !== 'cu') {
-        try {
-          temp = new serial.SerialPort('/dev/' + possible, {
-            baudrate: self.baudrate,
-            parser: serial.parsers.readline('\n')
-          });
-        } catch (e) {
-          err = e;
-        }
-        if (!err) {
-          found = temp;
-          self.log('info', 'found board at ' + temp.port);
-          break;
-        } else {
-          err = new Error('Could not find Arduino');
-        }
-      }
+    function skipUnwanted(e) {
+      return (e !== '') && (e.slice(0, 2) !== 'cu');
     }
 
-    callback(err, found);
+    var devices = stdout.slice(0, -1).split('\n').filter(skipUnwanted),
+        device,
+        candidate;
+
+    // loop over list of possible Arduinos
+    // do not stop (even/especially on error, that's the point!) until
+    //  - we run out of options, or
+    //  - a serial connection is established
+    var success = devices.some(function(device) {
+      try {
+        self.log('debug', 'attempting to open serial conn.: ' + device);
+        candidate = new serial.SerialPort('/dev/' + device, {
+          baudrate: self.baudrate,
+          parser: serial.parsers.readline('\n')
+        });
+
+        // connection succeeded, though we don't test whether it's an Arduino
+        self.log('info', 'found board at /dev/' + device);
+        return true;
+
+      } catch (e) {
+        // ignore error and cont.
+        self.log('warning', 'error while establishing serial connection with'
+                            + '/dev/' + device + '; trying next');
+        return false;
+      }
+    });
+
+    if (success) {
+      callback(candidate);
+    } else {
+      callback(false);
+    }
   });
 }
 
@@ -137,18 +166,17 @@ Board.prototype.write = function (m) {
   }
 }
 
-/*
- * Add a 0 to the front of a single-digit pin number
- */
+// Add a 0 to the front of a single-digit pin number
 Board.prototype.normalizePin = function (pin) {
   return this.lpad( 2, '0', pin );
 }
 
+// Left-pad values with 0s so it has three digits.
 Board.prototype.normalizeVal = function(val) {
-	return this.lpad( 3, '0', val );
+  return this.lpad( 3, '0', val );
 }
 
-//
+// Left-pad `str` with `chr` and return the last `len` digits
 Board.prototype.lpad = function(len, chr, str) {
   return (Array(len + 1).join(chr || ' ') + str).substr(-len);
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "name": "duino",
   "description": "Arduino framework for mad scientists",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "keywords": [
     "arduino",
     "serial",


### PR DESCRIPTION
Instead of trying to establish the serial connection in the Board constructor, delegate this to a separate `setup()`. (**API change**!)
This allows the user to add listeners to the Board’s `error` event, which signifies that the connection could not be established. (This was already intended, but wasn't possible, as far as I can tell.)
Also displays a more intuitive error message.
