### PR TITLE
better Arduino device search regular expression

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -12,7 +12,7 @@ var events = require('events'),
 var Board = function (options) {
   this.log('info', 'initializing');
   this.debug = options && options.debug || false;
-  this.device = options && options.device || 'usb|ttyACM*|ttyS0';
+  this.device = options && options.device || 'tty(USB|ACM|S)[0-9]?';
   this.baudrate = options && options.baudrate || 115200;
   this.writeBuffer = [];
 


### PR DESCRIPTION
Previous regular expression matches e.g. `/dev/usb`, which is undesirable. All Arduinos should show up as `/dev/tty(USB|ACM|S)[number]` (see [Arduino docs](http://playground.arduino.cc/Linux/All); `ttyS0` is reportedly for some clones or other non-standard *duinos).
